### PR TITLE
feat(api): implement stats endpoint

### DIFF
--- a/api/data/models.py
+++ b/api/data/models.py
@@ -3,7 +3,7 @@
 from enum import Enum
 from typing import Dict, List, Optional, TypeVar, Generic
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, RootModel
 
 
 class BuildCategory(str, Enum):
@@ -66,6 +66,61 @@ class Skill(BaseModel):
         ...,
         description="Categories this skill belongs to"
     )
+
+
+class StatValue(BaseModel):
+    """Value information for a stat modifier."""
+
+    conditions: List[str] = Field(
+        default_factory=list,
+        description="Conditions required for this value"
+    )
+    value: float = Field(..., description="Numeric value of the modifier")
+    unit: str = Field(..., description="Unit of measurement (e.g., 'percentage')")
+    scaling: bool = Field(
+        ...,
+        description="Whether this value scales with some factor"
+    )
+
+
+class StatModifier(BaseModel):
+    """Information about how an item modifies a stat."""
+
+    name: str = Field(..., description="Name of the item")
+    stars: Optional[str] = Field(None, description="Star rating if applicable")
+    base_values: List[StatValue] = Field(
+        default_factory=list,
+        description="Values at base level"
+    )
+    rank_10_values: List[StatValue] = Field(
+        default_factory=list,
+        description="Values at rank 10"
+    )
+    conditions: List[str] = Field(
+        default_factory=list,
+        description="General conditions for this modifier"
+    )
+    rank_10_conditions: List[str] = Field(
+        default_factory=list,
+        description="Conditions at rank 10"
+    )
+
+
+class StatInfo(BaseModel):
+    """Information about a game stat."""
+
+    gems: List[StatModifier] = Field(
+        default_factory=list,
+        description="Gem modifiers for this stat"
+    )
+    essences: List[StatModifier] = Field(
+        default_factory=list,
+        description="Essence modifiers for this stat"
+    )
+
+
+StatsResponse = RootModel[Dict[str, StatInfo]]
+"""Response model for stats endpoint."""
 
 
 # Generic type for paginated responses

--- a/api/data/routes.py
+++ b/api/data/routes.py
@@ -1,6 +1,6 @@
 """Game data routes."""
 
-from typing import Optional
+from typing import Optional, Union
 from fastapi import APIRouter, Depends, Query, Response
 from fastapi.exceptions import HTTPException
 from starlette import status
@@ -10,7 +10,8 @@ from .models import (
     GemBase,
     EquipmentSet,
     Skill,
-    PaginatedResponse
+    PaginatedResponse,
+    StatInfo
 )
 from .service import DataService, get_data_service
 
@@ -138,3 +139,23 @@ async def list_skills(
         page=page,
         per_page=per_page
     )
+
+
+@router.get(
+    "/stats",
+    response_model=Union[dict[str, StatInfo], StatInfo],
+    summary="Get stat relationships",
+    description="""
+    Get information about how different game elements affect various stats.
+    Can optionally filter to a specific stat.
+    """
+)
+async def list_stats(
+    stat: Optional[str] = Query(
+        None,
+        description="Specific stat to retrieve"
+    ),
+    data_service: DataService = Depends(get_data_service)
+):
+    """List stat relationships with optional filtering."""
+    return data_service.get_stats(stat=stat)

--- a/docs/api/v1.md
+++ b/docs/api/v1.md
@@ -285,89 +285,84 @@ Same format as Generate Build response.
 
 ### List Gems
 
-`GET /api/v1/data/gems`
+**GET /data/gems**
 
 List available gems with optional filtering.
 
-#### Query Parameters
+**Query Parameters:**
+- `stars` (optional): Filter by star rating (1, 2, or 5)
+- `category` (optional): Filter by category (movement, attack, etc.)
+- `page` (optional): Page number (default: 1)
+- `per_page` (optional): Items per page (default: 20, max: 100)
 
-- `stars`: Filter by star rating (1, 2, or 5)
-- `category`: Filter by category (movement, attack, defense, etc.)
-- `page`: Page number (default: 1)
-- `per_page`: Items per page (default: 20, max: 100)
-
-#### Response
+**Response:**
 
 ```json
 {
     "items": [
         {
-            "name": "Freedom and Devotion",
-            "stars": 2,
-            "base_effect": "Increases Movement Speed by 10%",
-            "rank_10_effect": "Increases Movement Speed by 20%",
-            "categories": ["movement"]
+            "name": "Berserker's Eye",
+            "stars": 1,
+            "base_effect": "Increases Critical Hit Chance",
+            "rank_10_effect": "Greatly increases Critical Hit Chance",
+            "categories": ["attack"]
         }
     ],
-    "total": 1,
+    "total": 50,
     "page": 1,
     "per_page": 20,
-    "total_pages": 1
+    "total_pages": 3
 }
 ```
 
 ### List Equipment Sets
 
-`GET /api/v1/data/sets`
+**GET /data/sets**
 
 List available equipment sets with optional filtering.
 
-#### Query Parameters
+**Query Parameters:**
+- `pieces` (optional): Filter by number of pieces (2, 4, or 6)
+- `page` (optional): Page number (default: 1)
+- `per_page` (optional): Items per page (default: 20, max: 100)
 
-- `pieces`: Filter by number of pieces (2, 4, or 6)
-- `page`: Page number (default: 1)
-- `per_page`: Items per page (default: 20, max: 100)
-
-#### Response
+**Response:**
 
 ```json
 {
     "items": [
         {
             "name": "Grace of the Flagellant",
-            "description": "A powerful set for damage dealers",
+            "description": "A set focused on continuous damage",
             "bonuses": {
-                "2": "+15% damage",
-                "4": "+30% damage",
-                "6": "+50% damage"
+                "2": "+15% Continuous Damage",
+                "4": "+30% Continuous Damage Duration"
             },
-            "use_case": "Best for high damage builds"
+            "use_case": "Best for DoT builds"
         }
     ],
-    "total": 1,
+    "total": 25,
     "page": 1,
     "per_page": 20,
-    "total_pages": 1
+    "total_pages": 2
 }
 ```
 
 ### List Skills
 
-`GET /api/v1/data/skills/{character_class}`
+**GET /data/skills/{character_class}**
 
 List available skills for a character class.
 
-#### Path Parameters
-
+**Path Parameters:**
 - `character_class`: Character class name (e.g., "barbarian")
 
-#### Query Parameters
+**Query Parameters:**
+- `category` (optional): Filter by category (movement, attack, etc.)
+- `page` (optional): Page number (default: 1)
+- `per_page` (optional): Items per page (default: 20, max: 100)
 
-- `category`: Filter by category (movement, attack, defense, etc.)
-- `page`: Page number (default: 1)
-- `per_page`: Items per page (default: 20, max: 100)
-
-#### Response
+**Response:**
 
 ```json
 {
@@ -376,13 +371,78 @@ List available skills for a character class.
             "name": "Whirlwind",
             "description": "Spin to win",
             "cooldown": 8.0,
-            "categories": ["attack", "channeled"]
+            "categories": ["attack", "movement"]
         }
     ],
-    "total": 1,
+    "total": 30,
     "page": 1,
     "per_page": 20,
-    "total_pages": 1
+    "total_pages": 2
+}
+```
+
+### List Stats
+
+**GET /data/stats**
+
+Get information about how different game elements affect various stats.
+
+**Query Parameters:**
+- `stat` (optional): Specific stat to retrieve (e.g., "critical_hit_chance")
+
+**Response (without stat filter):**
+
+```json
+{
+    "critical_hit_chance": {
+        "gems": [
+            {
+                "name": "Berserker's Eye",
+                "stars": "1",
+                "base_values": [],
+                "rank_10_values": [
+                    {
+                        "conditions": [],
+                        "value": 2.0,
+                        "unit": "percentage",
+                        "scaling": false
+                    }
+                ],
+                "conditions": [],
+                "rank_10_conditions": []
+            }
+        ],
+        "essences": []
+    },
+    "damage_increase": {
+        "gems": [...],
+        "essences": [...]
+    }
+}
+```
+
+**Response (with stat filter):**
+
+```json
+{
+    "gems": [
+        {
+            "name": "Berserker's Eye",
+            "stars": "1",
+            "base_values": [],
+            "rank_10_values": [
+                {
+                    "conditions": [],
+                    "value": 2.0,
+                    "unit": "percentage",
+                    "scaling": false
+                }
+            ],
+            "conditions": [],
+            "rank_10_conditions": []
+        }
+    ],
+    "essences": []
 }
 ```
 

--- a/tests/test_data/conftest.py
+++ b/tests/test_data/conftest.py
@@ -92,30 +92,168 @@ def mock_skills_data():
 
 
 @pytest.fixture
+def mock_stats_data():
+    """Mock stats data."""
+    return {
+        "critical_hit_chance": {
+            "gems": [
+                {
+                    "name": "Berserker's Eye",
+                    "stars": "1",
+                    "base_values": [],
+                    "rank_10_values": [
+                        {
+                            "conditions": [],
+                            "value": 2.0,
+                            "unit": "percentage",
+                            "scaling": False
+                        }
+                    ],
+                    "conditions": [],
+                    "rank_10_conditions": []
+                }
+            ],
+            "essences": []
+        },
+        "damage_increase": {
+            "gems": [
+                {
+                    "name": "Ruby",
+                    "stars": "2",
+                    "base_values": [
+                        {
+                            "conditions": [],
+                            "value": 5.0,
+                            "unit": "percentage",
+                            "scaling": False
+                        }
+                    ],
+                    "rank_10_values": [],
+                    "conditions": [],
+                    "rank_10_conditions": []
+                }
+            ],
+            "essences": [
+                {
+                    "name": "Lightning Core",
+                    "base_values": [
+                        {
+                            "conditions": [],
+                            "value": 15.0,
+                            "unit": "percentage",
+                            "scaling": False
+                        }
+                    ],
+                    "rank_10_values": [],
+                    "conditions": [],
+                    "rank_10_conditions": []
+                }
+            ]
+        },
+        "attack_speed": {
+            "gems": [
+                {
+                    "name": "Swift Stone",
+                    "stars": "3",
+                    "base_values": [
+                        {
+                            "conditions": [],
+                            "value": 3.0,
+                            "unit": "percentage",
+                            "scaling": False
+                        }
+                    ],
+                    "rank_10_values": [],
+                    "conditions": [],
+                    "rank_10_conditions": []
+                }
+            ],
+            "essences": []
+        },
+        "movement_speed": {
+            "gems": [
+                {
+                    "name": "Fleet Foot",
+                    "stars": "2",
+                    "base_values": [
+                        {
+                            "conditions": [],
+                            "value": 4.0,
+                            "unit": "percentage",
+                            "scaling": False
+                        }
+                    ],
+                    "rank_10_values": [],
+                    "conditions": [],
+                    "rank_10_conditions": []
+                }
+            ],
+            "essences": []
+        },
+        "life": {
+            "gems": [
+                {
+                    "name": "Ruby of Vitality",
+                    "stars": "3",
+                    "base_values": [
+                        {
+                            "conditions": [],
+                            "value": 10.0,
+                            "unit": "percentage",
+                            "scaling": False
+                        }
+                    ],
+                    "rank_10_values": [],
+                    "conditions": [],
+                    "rank_10_conditions": []
+                }
+            ],
+            "essences": [
+                {
+                    "name": "Life Core",
+                    "base_values": [
+                        {
+                            "conditions": [],
+                            "value": 20.0,
+                            "unit": "percentage",
+                            "scaling": False
+                        }
+                    ],
+                    "rank_10_values": [],
+                    "conditions": [],
+                    "rank_10_conditions": []
+                }
+            ]
+        }
+    }
+
+
+@pytest.fixture
 def mock_data_service(
     mock_gems_data,
     mock_sets_data,
     mock_skills_data,
+    mock_stats_data,
     tmp_path
 ):
     """Mock DataService fixture."""
-    # Create mock data files
+    # Create data directory structure
     data_dir = tmp_path / "data" / "indexed"
     data_dir.mkdir(parents=True)
-
-    # Create gems data
+    
+    # Create gems directory and files
     gems_dir = data_dir / "gems"
     gems_dir.mkdir()
     with open(gems_dir / "gems.json", "w") as f:
         json.dump(mock_gems_data, f)
-
-    # Create sets data
-    sets_dir = data_dir / "equipment"
-    sets_dir.mkdir()
-    with open(sets_dir / "sets.json", "w") as f:
+        
+    # Create equipment directory and files
+    equipment_dir = data_dir / "equipment"
+    equipment_dir.mkdir()
+    with open(equipment_dir / "sets.json", "w") as f:
         json.dump(mock_sets_data, f)
-
-    # Create skills data
+        
+    # Create classes directory and files
     classes_dir = data_dir / "classes"
     classes_dir.mkdir()
     barb_dir = classes_dir / "barbarian"
@@ -123,7 +261,10 @@ def mock_data_service(
     with open(barb_dir / "base_skills.json", "w") as f:
         json.dump(mock_skills_data["barbarian"], f)
 
-    # Create and return service instance
+    # Create stats file
+    with open(data_dir / "stats.json", "w") as f:
+        json.dump(mock_stats_data, f)
+    
     return DataService(data_dir=data_dir)
 
 

--- a/tests/test_data/test_service.py
+++ b/tests/test_data/test_service.py
@@ -167,3 +167,51 @@ def test_pagination(mock_data_service):
     assert result.page == 3
     assert result.per_page == 1
     assert len(result.items) == 0
+
+
+def test_get_stats(mock_data_service):
+    """Test getting all stats without filters."""
+    result = mock_data_service.get_stats()
+
+    # Verify basic structure
+    assert "critical_hit_chance" in result
+    assert "damage_increase" in result
+    assert "attack_speed" in result
+    assert "movement_speed" in result
+    assert "life" in result
+
+    # Verify stat details
+    crit = result["critical_hit_chance"]
+    assert len(crit.gems) > 0
+    assert len(crit.essences) >= 0
+
+    # Verify a specific gem
+    berserker = crit.gems[0]
+    assert berserker.name == "Berserker's Eye"
+    assert berserker.stars == "1"
+    assert len(berserker.rank_10_values) > 0
+    assert berserker.rank_10_values[0].value == 2.0
+
+
+def test_get_stats_filter_by_stat(mock_data_service):
+    """Test getting a specific stat."""
+    result = mock_data_service.get_stats(stat="critical_hit_chance")
+
+    # Verify stat details
+    assert len(result.gems) > 0
+    assert len(result.essences) >= 0
+
+    # Verify a specific gem
+    berserker = result.gems[0]
+    assert berserker.name == "Berserker's Eye"
+    assert berserker.stars == "1"
+    assert len(berserker.rank_10_values) > 0
+    assert berserker.rank_10_values[0].value == 2.0
+
+
+def test_get_stats_invalid_stat(mock_data_service):
+    """Test getting an invalid stat."""
+    with pytest.raises(HTTPException) as exc_info:
+        mock_data_service.get_stats(stat="invalid_stat")
+    assert exc_info.value.status_code == 404
+    assert "Stat not found" in str(exc_info.value.detail)


### PR DESCRIPTION
This commit adds a new /data/stats endpoint that provides information about how different game elements affect various stats. Key changes include:

- Add new models:
  - StatValue: Represents a stat modifier value with conditions
  - StatModifier: Represents how an item modifies a stat
  - StatInfo: Contains lists of gems and essences that affect a stat
  - StatsResponse: Root model for the API response

- Implement service layer:
  - Add get_stats method to DataService
  - Support filtering by specific stat
  - Handle file not found and invalid stat cases

- Add route implementation:
  - GET /data/stats endpoint
  - Optional stat query parameter
  - Response model supports both filtered and unfiltered cases

- Add comprehensive tests:
  - Test both service and routes layers
  - Cover all success and error cases
  - Add mock data for testing

- Update documentation:
  - Add stats endpoint to implementation plan
  - Document API usage in v1.md
  - Include example requests and responses